### PR TITLE
Homepage link was incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "safeps",
   "version": "2.2.9",
   "description": "Work with processes safely and easily with Node.js",
-  "homepage": "https://github.com/bevry/safefs",
+  "homepage": "https://github.com/bevry/safeps",
   "license": {
     "type": "MIT"
   },


### PR DESCRIPTION
The homepage field in the `package.json` points to [safefs](https://github.com/bevry/safefs) instead of [safeps](https://github.com/bevry/safeps).
