### PR TITLE
Ensures windows extension less spawns run as .cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Safe PS",
   "name": "safeps",
-  "version": "2.2.12",
+  "version": "2.3.0",
   "description": "Work with processes safely and easily with Node.js",
   "homepage": "https://github.com/bevry/safeps",
   "license": {


### PR DESCRIPTION
Updated version with a major to 3.0.0

This merge defaults all extension less command lines to spawn using '.cmd'  instead of the default '.exe'.
This gives windows users the ability to run commands like ```npm init``` and other npm package cmd's without having to write the extension just like linux and mac users enjoy using shebangs.

It's a pain that every time we want to run a command in node on windows we have to fiddle the command line when it's not an .exe file. It just adds annoying complexity to our cross-os-compatible scripts.

By creating .cmd wrappers for exe's and placing them in a common path (i.e. %userprofile%\appdata\roaming\npm\) they too can be run without specifying the ext. so this change seems the logical choice to me.

will fix [chainyjs/chainy-cli/issues/4](/chainyjs/chainy-cli/issues/4)