### PR TITLE
ensuring correct git branch before "pulling"

### DIFF
--- a/src/lib/safeps.coffee
+++ b/src/lib/safeps.coffee
@@ -882,7 +882,14 @@ safeps =
 		safefs.ensurePath opts.cwd, (err,exists) ->
 			return complete(err)  if err
 			if exists
-				safeps.spawn ['git', 'pull', opts.remote, opts.branch], opts, (err,result...) ->
+				# this ensures the repo is on the correct branch before performing a merge or fast-forward
+				commands = []
+				commands.push ['git', 'fetch', opts.remote]
+				commands.push ['git', 'checkout', opts.branch]
+				commands.push ['git', 'merge', "#{opts.remote}/#{opts.branch}"]
+
+				# Perform commands
+				safeps.spawnMultiple commands, opts, (err,result...) ->
 					return next(err, 'pull', result)
 			else
 				safeps.initGitRepo opts, (err,result) ->


### PR DESCRIPTION
Rather than performing a git pull, (which merges the desired branch into the current one, even if they aren't the same), this ensures the repo is on the correct branch before merging.

Fixes https://github.com/bevry/safeps/issues/7

I went with this variation instead of `reset --hard` option because it's less likely to surprise anyone by overwriting their local changes.
